### PR TITLE
use isEmpty function from _SynchronousQueue

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -71,7 +71,7 @@ _.extend Tracker,
     throwFirstError = !!_options?._throwFirstError
 
     try
-      while not _.isEmpty(queue._taskHandles) or afterFlushCallbacks.length
+      while not queue._taskHandles.isEmpty() or afterFlushCallbacks.length
         queue.drain()
 
         if afterFlushCallbacks.length


### PR DESCRIPTION
the previous implementation using underscore's isEmpty
lead to infinite loops under some circumstances.
This should fix #2 .
